### PR TITLE
Kompatibilität Contao 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require": {
     "php": ">=5.4",
-    "contao/core": ">3.4.4,<4.0",
+    "contao/core-bundle": "~3.4 || ~4.1",
     "contao-community-alliance/composer-plugin": "~2.0"
   },
   "extra": {


### PR DESCRIPTION
Kompatibilität für Contao 4, damit Installation aus Contao Manager möglich wird.